### PR TITLE
Upgrading Spring and Hibernate versions to 4.3.9 and 4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 	<version>1.2.2</version>
 
 	<properties>
-		<spring.version>3.2.2.RELEASE</spring.version>
-		<hibernate.version>4.2.0.Final</hibernate.version>
+		<spring.version>4.1.6.RELEASE</spring.version>
+		<hibernate.version>4.3.9.Final</hibernate.version>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<groupId>com.tikal.lazychopper</groupId>
 	<artifactId>lazy-chopper</artifactId>
 	<name>Lazy Chopper</name>
-	<version>1.2.2</version>
+	<version>1.2.3</version>
 
 	<properties>
 		<spring.version>4.1.6.RELEASE</spring.version>

--- a/src/main/java/com/tikal/lazychopper/DefaultLazyInitializationChopperAdvice.java
+++ b/src/main/java/com/tikal/lazychopper/DefaultLazyInitializationChopperAdvice.java
@@ -1,15 +1,15 @@
 package com.tikal.lazychopper;
 
-import java.lang.reflect.Field;
-import java.util.Collection;
-import java.util.Stack;
-
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.hibernate.collection.spi.PersistentCollection;
-import org.hibernate.envers.entities.mapper.relation.lazy.proxy.CollectionProxy;
+import org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.CollectionProxy;
 import org.hibernate.proxy.HibernateProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Stack;
 
 /*
  * assume that each time the service returns an object

--- a/src/main/java/com/tikal/lazychopper/EntityLazyInitializationChopper.java
+++ b/src/main/java/com/tikal/lazychopper/EntityLazyInitializationChopper.java
@@ -1,5 +1,21 @@
 package com.tikal.lazychopper;
 
+import com.tikal.lazychopper.GraphTraverser.TraverseException;
+import org.hibernate.Hibernate;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.envers.internal.entities.mapper.relation.lazy.proxy.CollectionProxy;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.proxy.LazyInitializer;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.core.type.classreading.CachingMetadataReaderFactory;
+import org.springframework.core.type.classreading.MetadataReader;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.util.ClassUtils;
+
+import javax.persistence.EmbeddedId;
+import javax.persistence.Id;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -12,24 +28,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import javax.persistence.EmbeddedId;
-import javax.persistence.Id;
-
-import org.hibernate.Hibernate;
-import org.hibernate.collection.spi.PersistentCollection;
-import org.hibernate.envers.entities.mapper.relation.lazy.proxy.CollectionProxy;
-import org.hibernate.proxy.HibernateProxy;
-import org.hibernate.proxy.LazyInitializer;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
-import org.springframework.core.io.support.ResourcePatternResolver;
-import org.springframework.core.type.classreading.CachingMetadataReaderFactory;
-import org.springframework.core.type.classreading.MetadataReader;
-import org.springframework.core.type.classreading.MetadataReaderFactory;
-import org.springframework.util.ClassUtils;
-
-import com.tikal.lazychopper.GraphTraverser.TraverseException;
 
 public class EntityLazyInitializationChopper implements LazyInitializationChopper {
 


### PR DESCRIPTION
A couple of internal packages were moved in Hibernate 4.3 related to Envers.
